### PR TITLE
Avoid hooking into Android native packages

### DIFF
--- a/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
+++ b/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
@@ -9,11 +9,7 @@ import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
 
 class HideDevOpts : IXposedHookLoadPackage {
 
-    override fun handleLoadPackage(lpparam: LoadPackageParam?) {
-        if (lpparam == null) {
-            return
-        }
-
+    override fun handleLoadPackage(lpparam: LoadPackageParam) {
         if (
             lpparam.packageName.startsWith("com.android.")
             || lpparam.packageName.startsWith("com.google.android.")

--- a/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
+++ b/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
@@ -4,7 +4,6 @@ import android.content.ContentResolver
 import android.provider.Settings
 import de.robv.android.xposed.IXposedHookLoadPackage
 import de.robv.android.xposed.XC_MethodHook
-import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers.findAndHookMethod
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam
 
@@ -14,7 +13,6 @@ class HideDevOpts : IXposedHookLoadPackage {
         if (lpparam == null) {
             return
         }
-        XposedBridge.log("Found package: ${lpparam.packageName}")
 
         listOf(Settings.Secure::class.java, Settings.Global::class.java).forEach { parent ->
             findAndHookMethod(

--- a/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
+++ b/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
@@ -14,6 +14,13 @@ class HideDevOpts : IXposedHookLoadPackage {
             return
         }
 
+        if (
+            lpparam.packageName.startsWith("com.android.")
+            || lpparam.packageName.startsWith("com.google.android.")
+        ) {
+            return
+        }
+
         listOf(Settings.Secure::class.java, Settings.Global::class.java).forEach { parent ->
             findAndHookMethod(
                 parent,


### PR DESCRIPTION
Namely `com.android.` and `com.google.android.`

Saves adding a handful of hooks (on about 100+ packages), for performances.

This app is needed only for some third-party apps, thus it shouldn't be needed in Android native packages.