### PR TITLE
Add override of getString method

### DIFF
--- a/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
+++ b/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
@@ -34,6 +34,14 @@ class HideDevOpts : IXposedHookLoadPackage {
                 Int::class.java,
                 callback,
             )
+
+            findAndHookMethod(
+                parent,
+                "getString",
+                ContentResolver::class.java,
+                String::class.java,
+                callback,
+            )
         }
     }
 
@@ -53,7 +61,11 @@ class HideDevOpts : IXposedHookLoadPackage {
                     return
                 }
 
-                param.result = 0
+                param.result = when (param.method.getName()) {
+                    "getInt" -> 0
+                    "getString" -> "0"
+                    else -> error("Illegal method name passed.")
+                }
             }
         }
     }

--- a/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
+++ b/app/src/main/java/net/accelf/devoptshide/HideDevOpts.kt
@@ -52,10 +52,9 @@ class HideDevOpts : IXposedHookLoadPackage {
         )
 
         private val callback = object : XC_MethodHook() {
-            override fun beforeHookedMethod(param: MethodHookParam?) {
+            override fun beforeHookedMethod(param: MethodHookParam) {
                 if (
-                    param == null
-                    || param.args[1] !is String
+                    param.args[1] !is String
                     || !names.contains(param.args[1] as String)
                 ) {
                     return


### PR DESCRIPTION
As pointed out on https://github.com/accelforce/DevOptsHide/issues/16. This should make DevOptsHide work with more apps.

Thankfully, the `MethodHookParam` object has a `method` property ([see in XC_MethodHook.java](https://github.com/rovo89/XposedBridge/blob/a535c02ed9dfd53683cc0274d9f95bcb6ffb9f79/app/src/main/java/de/robv/android/xposed/XC_MethodHook.java#L63-L75)), so we can make use of [java.lang.reflect.Member.getName()](https://docs.oracle.com/en/java/javase/17/docs/api//java.base/java/lang/reflect/Member.html#getName()).

(there are other ways to write this code, so maybe someone could think of a more factorized/performant implementation)